### PR TITLE
Add or update readme with baloon.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Example React App with [chakra-ui](https://github.com/chakra-ui/chakra-ui) and TypeScript
 
-This repository is a **sample project for [Baloon.dev](https://baloon.dev)**.
-The goal is to demonstrate how you can use Baloon with a real front-end repository to create Jira issues, make relevant code changes, and preview updates seamlessly.
+This repository is a **sample project for [baloon.dev](https://baloon.dev)**.
+The goal is to demonstrate how you can use baloon.dev with a real front-end repository to create Jira issues, make relevant code changes, and preview updates seamlessly.
 
-We’re using a simple **Next.js + chakra-ui + TypeScript** app as the base project. You can try making changes via Baloon and see how it applies updates across the repo.
+We’re using a simple **Next.js + chakra-ui + TypeScript** app as the base project. You can try making changes via baloon.dev and see how it applies updates across the repo.
 
 👉 Screenshot and workflow examples will be added soon.
 


### PR DESCRIPTION
Update README.md to use "baloon.dev" (lowercase) instead of "Baloon.dev" as requested in JIRA issue BD-38.

---
<a href="https://cursor.com/background-agent?bcId=bc-b51b549d-e812-4b73-800c-99ed816ce97b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b51b549d-e812-4b73-800c-99ed816ce97b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

