### PR TITLE
Add test file dragonefile.txt to root

### DIFF
--- a/dragonefile.txt
+++ b/dragonefile.txt
@@ -1,0 +1,2 @@
+BD-67 placeholder file for automated tests.
+Keep this file at the repository root unless BD-67 requirements change.


### PR DESCRIPTION
Add `dragonefile.txt` to the repository root to serve as a placeholder for BD-67 automated tests.

---
<a href="https://cursor.com/background-agent?bcId=bc-19efaec9-c11c-4b4f-9f56-023e9b735fb5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-19efaec9-c11c-4b4f-9f56-023e9b735fb5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

