### PR TITLE
Add test file dragonefile2345433332.txt

### DIFF
--- a/dragonefile2345433332.txt
+++ b/dragonefile2345433332.txt
@@ -1,0 +1,3 @@
+BD-69 placeholder file for verification.
+Ensures dragonefile2345433332.txt exists at repository root.
+Generated automatically to satisfy testing requirements.


### PR DESCRIPTION
Add `dragonefile2345433332.txt` to the root directory to satisfy a testing requirement for BD-69.

---
<a href="https://cursor.com/background-agent?bcId=bc-1e4073c9-9f53-4cc6-96cb-f4f9508ee053"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1e4073c9-9f53-4cc6-96cb-f4f9508ee053"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

